### PR TITLE
Improvements for the patch

### DIFF
--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtend2/lib/StringConcatenation.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtend2/lib/StringConcatenation.java
@@ -120,7 +120,9 @@ public class StringConcatenation implements CharSequence {
 	protected void append(Object object, int index) {
 		if (object == null)
 			return;
-		if (object instanceof StringConcatenation) {
+		if (object instanceof String) {
+			append((String)object, index);
+		} else if (object instanceof StringConcatenation) {
 			StringConcatenation other = (StringConcatenation) object;
 			appendSegments(index, other.getSignificantContent(), other.lineDelimiter);
 			return;
@@ -130,15 +132,7 @@ public class StringConcatenation implements CharSequence {
 			return;
 		} else {
 			String value = getStringRepresentation(object);
-			if (value != null) {
-				int initial = initialSegmentSize(value);
-				if (initial != value.length()) {
-					List<String> newSegments = continueSplitting(value, initial, value.length());
-					appendSegments(index, newSegments, lineDelimiter);
-				} else {
-					appendSegment(index, value, lineDelimiter);
-				}
-			}
+			append(value, index);
 		}
 	}
 
@@ -173,7 +167,9 @@ public class StringConcatenation implements CharSequence {
 		}
 		if (object == null)
 			return;
-		if (object instanceof StringConcatenation) {
+		if (object instanceof String) {
+			append((String)object,index);
+		} else if (object instanceof StringConcatenation) {
 			StringConcatenation other = (StringConcatenation) object;
 			List<String> otherSegments = other.getSignificantContent();
 			appendSegments(indentation, index, otherSegments, other.lineDelimiter);
@@ -182,15 +178,17 @@ public class StringConcatenation implements CharSequence {
 			other.appendTo(new IndentedTarget(this, indentation, index));
 		} else {
 			String value = getStringRepresentation(object);
-			if (value != null) {
-				int initial = initialSegmentSize(value);
-				if (initial != value.length()) {
-					List<String> newSegments = continueSplitting(value, initial, value.length());
-					appendSegments(indentation, index, newSegments, lineDelimiter);
-				} else {
-					appendSegment(indentation, index, value, lineDelimiter);
-				}
-			}
+			append(value,index);
+		}
+	}
+
+	private void append(String value, int index) {
+		int initial = initialSegmentSize(value);
+		if (initial != value.length()) {
+			List<String> newSegments = continueSplitting(value, initial, value.length());
+			appendSegments(index, newSegments, lineDelimiter);
+		} else {
+			appendSegment(index, value, lineDelimiter);
 		}
 	}
 

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtend2/lib/StringConcatenation.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtend2/lib/StringConcatenation.java
@@ -254,7 +254,7 @@ public class StringConcatenation implements CharSequence {
 		cachedToString = null;
 	}
 
-	protected int appendSegment(String indentation, int index, String otherSegment, String otherDelimiter) {
+	private int appendSegment(String indentation, int index, String otherSegment, String otherDelimiter) {
 		if (otherDelimiter.equals(otherSegment)) {
 			if (index != segments.size()) {
 				segments.add(index++, lineDelimiter);
@@ -276,12 +276,12 @@ public class StringConcatenation implements CharSequence {
 		return index;
 	}
 
-	protected void appendSegment(int index, String otherSegment) {
+	private void appendSegment(int index, String otherSegment) {
 		segments.add(index, otherSegment);
 		cachedToString = null;
 	}
 
-	protected void appendSegment(int index, String otherSegment, String otherDelimiter) {
+	private void appendSegment(int index, String otherSegment, String otherDelimiter) {
 		if (otherDelimiter.equals(lineDelimiter)) {
 			appendSegment(index, otherSegment);
 		} else {
@@ -479,7 +479,7 @@ public class StringConcatenation implements CharSequence {
 		return toString().subSequence(start, end);
 	}
 
-	protected int initialSegmentSize(String text) {
+	private int initialSegmentSize(String text) {
 		int length = text.length();
 		int idx = 0;
 		while (idx < length) {
@@ -493,7 +493,7 @@ public class StringConcatenation implements CharSequence {
 		return idx;
 	}
 
-	protected List<String> continueSplitting(String text, int idx, int length) {
+	private List<String> continueSplitting(String text, int idx, int length) {
 		int nextLineOffset = 0;
 		List<String> result = new ArrayList<String>(5);
 		while (idx < length) {


### PR DESCRIPTION
- The likliest case for append is with a String object, so handling this case first is better than always checking for instances of StringConcatenation or StringConcatenationClient before handling other objects.
- Extracted a method `append(String,int)` to reduce code.
- Made new methods private
- `value` can't be null, so the guard is obsolete